### PR TITLE
TF 1.3 Upgrade

### DIFF
--- a/groups/advanced-search/README.md
+++ b/groups/advanced-search/README.md
@@ -2,27 +2,70 @@
 
 Provisions an elasticsearch cluster
 
-# Terraform variables
 
-| Name                            | Description                                                                                  | Default                     | Example                   | Notes                                                 |
-| ------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------- | ------------------------- | ----------------------------------------------------- |
-| account_name                    | The name of the AWS account we're using                                                      | `-`                         | `development`             | -                                                     |
-| cloudwatch_logging_enabled      | A boolean value indicating whether cloudwatch logging is enabled                             | `false`                     | `true`                    | -                                                     |
-| dedicated_master_enabled        | A boolean value indicating whether dedicated master nodes are enabled for the cluster        | `false`                     | `true`                    | -                                                     |
-| dedicated_master_instance_count | Number of dedicated master instances in the cluster                                          | `0`                         | `3`                       | Applicable only when dedicated master mode is enabled |
-| dedicated_master_instance_type  | Instance type of dedicated master nodes                                                      | `-`                         | `t3.medium.elasticsearch` | Applicable only when dedicated master mode is enabled |
-| elasticsearch_version           | The version of AWS ElasticSearch to use when creating the cluster                            | `7.10`                      | `7.9`                     | -                                                     |
-| environment                     | The environment name to be used when creating AWS resources                                  | `-`                         | `my_environment`          | -                                                     |
-| es_application_logs_enabled     | A boolean value indicating whether application logs are enabled                              | `false`                     | `true`                    | -                                                     |
-| es_instance_count               | The number of ElasticSearch EC2 instances to be provisioned                                  | `1`                         | `3`                       | -                                                     |
-| es_instance_type                | The type of ElasticSearch EC2 instance to be provisioned                                     | `-`                         | `t3.medium.elasticsearch` | -                                                     |
-| index_slow_logs_enabled         | A boolean value indicating whether index slow logs are enabled                               | `false`                     | `true`                    | -                                                     |
-| region                          | The AWS region in which resources will be administered                                       | `-`                         | `eu-west-2`               | -                                                     |
-| repository_name                 | The name of the repository in which we're operating                                          | `advanced-search-terraform` | `-`                       | -                                                     |
-| search_slow_logs_enabled        | A boolean value indicating whether search slow logs are enabled                              | `false`                     | `true`                    | -                                                     |
-| service                         | The service name to be used when creating AWS resources                                      | `advanced-search`           | `-`                       | -                                                     |
-| snapshots_enabled               | A boolean value indicating whether automated daily snapshots are enabled                     | `false`                     | `true`                    | -                                                     |
-| snapshot_start_hour             | Hour during which the service takes an automated daily snapshot of the indices in the domain | `23`                        | `22`                      | -                                                     |
-| team                            | The team responsible for administering the instance                                          | `platform`                  | `apollo`                  | -                                                     |
-| volume_size                     | The volume size in GB                                                                        | `20`                        | `30`                      | -                                                     |
-| vpc_name                        | The name of the VPC into which we're provisioning                                            | `-`                         | `my_vpc`                  | -                                                     |
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 5.0, < 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | >= 5.0, < 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_advanced_search"></a> [advanced\_search](#module\_advanced\_search) | ./module-advanced-search | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_ec2_managed_prefix_list.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
+| [aws_subnet.accessible_from](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnet.placement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnets.accessible_from](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.placement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [vault_generic_secret.secrets](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_name"></a> [account\_name](#input\_account\_name) | The name of the AWS account we're using | `string` | n/a | yes |
+| <a name="input_cloudwatch_logging_enabled"></a> [cloudwatch\_logging\_enabled](#input\_cloudwatch\_logging\_enabled) | A boolean value indicating whether cloudwatch logging is enabled; overrides other *\_logs\_enabled variables | `bool` | `false` | no |
+| <a name="input_dedicated_master_enabled"></a> [dedicated\_master\_enabled](#input\_dedicated\_master\_enabled) | A boolean value indicating whether dedicated master nodes are enabled for the cluster | `bool` | `false` | no |
+| <a name="input_dedicated_master_instance_count"></a> [dedicated\_master\_instance\_count](#input\_dedicated\_master\_instance\_count) | Number of dedicated master instances in the cluster; applicable only when dedicated master mode is enabled | `number` | `0` | no |
+| <a name="input_dedicated_master_instance_type"></a> [dedicated\_master\_instance\_type](#input\_dedicated\_master\_instance\_type) | Instance type of dedicated master nodes; applicable only when dedicated master mode is enabled | `string` | n/a | yes |
+| <a name="input_elasticsearch_version"></a> [elasticsearch\_version](#input\_elasticsearch\_version) | The version of AWS ElasticSearch to use when creating the cluster | `string` | `"7.10"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name to be used when creating AWS resources | `string` | n/a | yes |
+| <a name="input_es_application_logs_enabled"></a> [es\_application\_logs\_enabled](#input\_es\_application\_logs\_enabled) | A boolean value indicating whether application logs are enabled | `bool` | `false` | no |
+| <a name="input_es_instance_count"></a> [es\_instance\_count](#input\_es\_instance\_count) | The number of ElasticSearch EC2 instances to be provisioned | `number` | `1` | no |
+| <a name="input_es_instance_type"></a> [es\_instance\_type](#input\_es\_instance\_type) | The type of ElasticSearch EC2 instance to be provisioned | `string` | n/a | yes |
+| <a name="input_hashicorp_vault_password"></a> [hashicorp\_vault\_password](#input\_hashicorp\_vault\_password) | The password used when retrieving configuration from Hashicorp Vault | `string` | n/a | yes |
+| <a name="input_hashicorp_vault_username"></a> [hashicorp\_vault\_username](#input\_hashicorp\_vault\_username) | The username used when retrieving configuration from Hashicorp Vault | `string` | n/a | yes |
+| <a name="input_index_slow_logs_enabled"></a> [index\_slow\_logs\_enabled](#input\_index\_slow\_logs\_enabled) | A boolean value indicating whether index slow logs are enabled | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region in which resources will be administered | `string` | n/a | yes |
+| <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | The name of the repository in which we're operating | `string` | `"advanced-search-terraform"` | no |
+| <a name="input_search_slow_logs_enabled"></a> [search\_slow\_logs\_enabled](#input\_search\_slow\_logs\_enabled) | A boolean value indicating whether search slow logs are enabled | `bool` | `false` | no |
+| <a name="input_service"></a> [service](#input\_service) | The service name to be used when creating AWS resources | `string` | `"advanced-search"` | no |
+| <a name="input_snapshot_start_hour"></a> [snapshot\_start\_hour](#input\_snapshot\_start\_hour) | Hour during which the service takes an automated daily snapshot of the indices in the domain | `string` | `23` | no |
+| <a name="input_snapshots_enabled"></a> [snapshots\_enabled](#input\_snapshots\_enabled) | A boolean value indicating whether automated daily snapshots are enabled | `bool` | `false` | no |
+| <a name="input_team"></a> [team](#input\_team) | The team responsible for administering the instance | `string` | `"platform"` | no |
+| <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | The volume size in GB | `string` | `20` | no |
+| <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | The name of the VPC into which we're provisioning | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/groups/advanced-search/data.tf
+++ b/groups/advanced-search/data.tf
@@ -43,10 +43,10 @@ data "aws_vpc" "vpc" {
   }
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
-}
-
 data "vault_generic_secret" "secrets" {
   path = "team-${var.team}/${var.account_name}/${var.region}/${var.environment}/${var.repository_name}"
+}
+
+data "aws_ec2_managed_prefix_list" "admin" {
+  name = "administration-cidr-ranges"
 }

--- a/groups/advanced-search/data.tf
+++ b/groups/advanced-search/data.tf
@@ -1,17 +1,22 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_subnet" "accessible_from" {
-  count = length(data.aws_subnet_ids.accessible_from.ids)
-  id    = tolist(data.aws_subnet_ids.accessible_from.ids)[count.index]
+  count = length(data.aws_subnets.accessible_from.ids)
+
+  id = data.aws_subnets.accessible_from.ids[count.index]
 }
 
 data "aws_subnet" "placement" {
-  count = length(data.aws_subnet_ids.placement.ids)
-  id    = tolist(data.aws_subnet_ids.placement.ids)[count.index]
+  count = length(data.aws_subnets.placement.ids)
+
+  id = data.aws_subnets.placement.ids[count.index]
 }
 
-data "aws_subnet_ids" "accessible_from" {
-  vpc_id = data.aws_vpc.vpc.id
+data "aws_subnets" "accessible_from" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
 
   filter {
     name   = "tag:Name"
@@ -19,8 +24,11 @@ data "aws_subnet_ids" "accessible_from" {
   }
 }
 
-data "aws_subnet_ids" "placement" {
-  vpc_id = data.aws_vpc.vpc.id
+data "aws_subnets" "placement" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
 
   filter {
     name   = "tag:Name"

--- a/groups/advanced-search/locals.tf
+++ b/groups/advanced-search/locals.tf
@@ -2,12 +2,12 @@ locals {
   secrets = data.vault_generic_secret.secrets.data
 
   accessible_from_subnet_patterns = jsondecode(local.secrets.accessible_from_subnet_patterns)
-  availability_zone_count = length(data.aws_subnets.placement.ids)
-  placement_subnet_pattern = local.secrets.placement_subnet_pattern
+  availability_zone_count         = length(data.aws_subnets.placement.ids)
+  placement_subnet_pattern        = local.secrets.placement_subnet_pattern
 
   zone_awareness_enabled = local.availability_zone_count > 1
 
-  cluster_accessible_cidrs           = data.aws_subnet.accessible_from[*].cidr_block
+  cluster_accessible_cidrs = data.aws_subnet.accessible_from[*].cidr_block
   cluster_accessible_prefix_list_ids = [
     data.aws_ec2_managed_prefix_list.admin.id
   ]

--- a/groups/advanced-search/locals.tf
+++ b/groups/advanced-search/locals.tf
@@ -1,9 +1,9 @@
 locals {
   secrets = data.vault_generic_secret.secrets.data
+  admin_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
 
   accessible_from_subnet_patterns = jsondecode(local.secrets.accessible_from_subnet_patterns)
-  admin_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
-  availability_zone_count = length(data.aws_subnet_ids.placement.ids)
+  availability_zone_count = length(data.aws_subnets.placement.ids)
   placement_subnet_pattern = local.secrets.placement_subnet_pattern
 
   zone_awareness_enabled = local.availability_zone_count > 1

--- a/groups/advanced-search/locals.tf
+++ b/groups/advanced-search/locals.tf
@@ -1,6 +1,5 @@
 locals {
   secrets = data.vault_generic_secret.secrets.data
-  admin_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
 
   accessible_from_subnet_patterns = jsondecode(local.secrets.accessible_from_subnet_patterns)
   availability_zone_count = length(data.aws_subnets.placement.ids)
@@ -8,5 +7,8 @@ locals {
 
   zone_awareness_enabled = local.availability_zone_count > 1
 
-  cluster_accessible_cidrs = concat(local.admin_cidrs, data.aws_subnet.accessible_from[*].cidr_block)
+  cluster_accessible_cidrs           = data.aws_subnet.accessible_from[*].cidr_block
+  cluster_accessible_prefix_list_ids = [
+    data.aws_ec2_managed_prefix_list.admin.id
+  ]
 }

--- a/groups/advanced-search/main.tf
+++ b/groups/advanced-search/main.tf
@@ -1,9 +1,21 @@
-provider "aws" {
-  region = var.region
+terraform {
+  required_version = ">= 0.13, < 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+
+  backend "s3" {}
 }
 
-terraform {
-  backend "s3" {}
+provider "aws" {
+  region = var.region
 }
 
 module "advanced_search" {
@@ -22,7 +34,7 @@ module "advanced_search" {
   es_instance_count               = var.es_instance_count
   es_instance_type                = var.es_instance_type
   index_slow_logs_enabled         = var.index_slow_logs_enabled
-  placement_subnet_ids            = data.aws_subnet_ids.placement.ids
+  placement_subnet_ids            = data.aws_subnets.placement.ids
   region                          = var.region
   search_slow_logs_enabled        = var.search_slow_logs_enabled
   service                         = var.service

--- a/groups/advanced-search/main.tf
+++ b/groups/advanced-search/main.tf
@@ -21,26 +21,29 @@ provider "aws" {
 module "advanced_search" {
   source                          = "./module-advanced-search"
 
+  aws_account_id       = data.aws_caller_identity.current.account_id
+  environment          = var.environment
+  placement_subnet_ids = data.aws_subnets.placement.ids
+  region               = var.region
+  service              = var.service
+  vpc_id               = data.aws_vpc.vpc.id
+
   availability_zone_count         = local.availability_zone_count
-  aws_account_id                  = data.aws_caller_identity.current.account_id
   cloudwatch_logging_enabled      = var.cloudwatch_logging_enabled
-  cluster_accessible_cidrs        = local.cluster_accessible_cidrs
   dedicated_master_enabled        = var.dedicated_master_enabled
   dedicated_master_instance_count = var.dedicated_master_instance_count
   dedicated_master_instance_type  = var.dedicated_master_instance_type
   elasticsearch_version           = var.elasticsearch_version
-  environment                     = var.environment
   es_application_logs_enabled     = var.es_application_logs_enabled
   es_instance_count               = var.es_instance_count
   es_instance_type                = var.es_instance_type
   index_slow_logs_enabled         = var.index_slow_logs_enabled
-  placement_subnet_ids            = data.aws_subnets.placement.ids
-  region                          = var.region
   search_slow_logs_enabled        = var.search_slow_logs_enabled
-  service                         = var.service
   snapshots_enabled               = var.snapshots_enabled
   snapshot_start_hour             = var.snapshot_start_hour
   volume_size                     = var.volume_size
-  vpc_id                          = data.aws_vpc.vpc.id
   zone_awareness_enabled          = local.zone_awareness_enabled
+
+  cluster_accessible_cidrs           = local.cluster_accessible_cidrs
+  cluster_accessible_prefix_list_ids = local.cluster_accessible_prefix_list_ids
 }

--- a/groups/advanced-search/main.tf
+++ b/groups/advanced-search/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13, < 0.14"
+  required_version = ">= 1.3, < 2.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/groups/advanced-search/main.tf
+++ b/groups/advanced-search/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 module "advanced_search" {
-  source                          = "./module-advanced-search"
+  source = "./module-advanced-search"
 
   aws_account_id       = data.aws_caller_identity.current.account_id
   environment          = var.environment

--- a/groups/advanced-search/module-advanced-search/data.tf
+++ b/groups/advanced-search/module-advanced-search/data.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "advanced_search_elasticsearch" {
     sid = "AllowAccessToElasticSearchCluster"
 
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = ["*"]
     }
 

--- a/groups/advanced-search/module-advanced-search/elasticsearch.tf
+++ b/groups/advanced-search/module-advanced-search/elasticsearch.tf
@@ -6,7 +6,7 @@ resource "aws_elasticsearch_domain" "advanced_search_elasticsearch" {
 
   # Dedicated master mode
   dynamic "cluster_config" {
-    for_each                   = var.dedicated_master_enabled ? [var.dedicated_master_instance_count] : []
+    for_each = var.dedicated_master_enabled ? [var.dedicated_master_instance_count] : []
 
     content {
       instance_type            = var.instance_type
@@ -27,7 +27,7 @@ resource "aws_elasticsearch_domain" "advanced_search_elasticsearch" {
 
   # Shared master/data node mode
   dynamic "cluster_config" {
-    for_each                 = var.dedicated_master_enabled ? [] : [var.dedicated_master_instance_count]
+    for_each = var.dedicated_master_enabled ? [] : [var.dedicated_master_instance_count]
 
     content {
       instance_type          = var.es_instance_type

--- a/groups/advanced-search/module-advanced-search/security-groups.tf
+++ b/groups/advanced-search/module-advanced-search/security-groups.tf
@@ -3,13 +3,6 @@ resource "aws_security_group" "advanced_search_elasticsearch" {
   vpc_id      = var.vpc_id
 
   ingress = []
-#  ingress {
-#    from_port   = 443
-#    to_port     = 443
-#    protocol    = "tcp"
-#    description = "Inbound HTTPS access to Elasticsearch cluster endpoint from VPC"
-#    cidr_blocks = var.cluster_accessible_cidrs
-#  }
 
   tags = {
     Name         = "${var.environment}-${var.service}-elasticsearch-security-group"

--- a/groups/advanced-search/module-advanced-search/security-groups.tf
+++ b/groups/advanced-search/module-advanced-search/security-groups.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "advanced_search_elasticsearch" {
-  name        = "${var.environment}-${var.service}-elasticsearch-security-group"
-  vpc_id      = var.vpc_id
+  name   = "${var.environment}-${var.service}-elasticsearch-security-group"
+  vpc_id = var.vpc_id
 
   ingress = []
 

--- a/groups/advanced-search/module-advanced-search/security-groups.tf
+++ b/groups/advanced-search/module-advanced-search/security-groups.tf
@@ -2,13 +2,14 @@ resource "aws_security_group" "advanced_search_elasticsearch" {
   name        = "${var.environment}-${var.service}-elasticsearch-security-group"
   vpc_id      = var.vpc_id
 
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    description = "Inbound HTTPS access to Elasticsearch cluster endpoint from VPC"
-    cidr_blocks = var.cluster_accessible_cidrs
-  }
+  ingress = []
+#  ingress {
+#    from_port   = 443
+#    to_port     = 443
+#    protocol    = "tcp"
+#    description = "Inbound HTTPS access to Elasticsearch cluster endpoint from VPC"
+#    cidr_blocks = var.cluster_accessible_cidrs
+#  }
 
   tags = {
     Name         = "${var.environment}-${var.service}-elasticsearch-security-group"
@@ -17,4 +18,28 @@ resource "aws_security_group" "advanced_search_elasticsearch" {
     AnsibleGroup = "${var.service}-${var.environment}"
   }
   lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "cidrs" {
+  for_each = toset(var.cluster_accessible_cidrs)
+
+  security_group_id = aws_security_group.advanced_search_elasticsearch.id
+
+  description = "Inbound HTTPS access to Elasticsearch cluster endpoint from ${each.value}"
+  cidr_ipv4   = each.value
+  from_port   = 443
+  ip_protocol = "tcp"
+  to_port     = 443
+}
+
+resource "aws_vpc_security_group_ingress_rule" "prefix_lists" {
+  for_each = toset(var.cluster_accessible_prefix_list_ids)
+
+  security_group_id = aws_security_group.advanced_search_elasticsearch.id
+
+  description    = "Inbound HTTPS access to Elasticsearch cluster endpoint from ${each.value}"
+  from_port      = 443
+  ip_protocol    = "tcp"
+  prefix_list_id = each.value
+  to_port        = 443
 }

--- a/groups/advanced-search/module-advanced-search/variables.tf
+++ b/groups/advanced-search/module-advanced-search/variables.tf
@@ -105,7 +105,7 @@ variable "volume_size" {
 
 variable "vpc_id" {
   description = "The ID of the VPC to be used"
-  type = string
+  type        = string
 }
 
 variable "zone_awareness_enabled" {

--- a/groups/advanced-search/module-advanced-search/variables.tf
+++ b/groups/advanced-search/module-advanced-search/variables.tf
@@ -18,6 +18,11 @@ variable "cluster_accessible_cidrs" {
   type        = list(string)
 }
 
+variable "cluster_accessible_prefix_list_ids" {
+  description = "A list of prefix list Ids that the cluster will be accessible from"
+  type        = list(string)
+}
+
 variable "dedicated_master_enabled" {
   description = "A boolean value indicating whether dedicated master nodes are enabled for the cluster"
   type        = bool

--- a/groups/advanced-search/variables.tf
+++ b/groups/advanced-search/variables.tf
@@ -4,32 +4,32 @@ variable "account_name" {
 }
 
 variable "cloudwatch_logging_enabled" {
-  default       = false
-  description   = "A boolean value indicating whether cloudwatch logging is enabled; overrides other *_logs_enabled variables"
-  type          = bool
+  default     = false
+  description = "A boolean value indicating whether cloudwatch logging is enabled; overrides other *_logs_enabled variables"
+  type        = bool
 }
 
 variable "dedicated_master_enabled" {
-  default       = false
-  description   = "A boolean value indicating whether dedicated master nodes are enabled for the cluster"
-  type          = bool
+  default     = false
+  description = "A boolean value indicating whether dedicated master nodes are enabled for the cluster"
+  type        = bool
 }
 
 variable "dedicated_master_instance_count" {
-  default       = 0
-  description   = "Number of dedicated master instances in the cluster; applicable only when dedicated master mode is enabled"
-  type          = number
+  default     = 0
+  description = "Number of dedicated master instances in the cluster; applicable only when dedicated master mode is enabled"
+  type        = number
 }
 
 variable "dedicated_master_instance_type" {
-  description   = "Instance type of dedicated master nodes; applicable only when dedicated master mode is enabled"
-  type          = string
+  description = "Instance type of dedicated master nodes; applicable only when dedicated master mode is enabled"
+  type        = string
 }
 
 variable "elasticsearch_version" {
-  default       = "7.10"
-  description   = "The version of AWS ElasticSearch to use when creating the cluster"
-  type          = string
+  default     = "7.10"
+  description = "The version of AWS ElasticSearch to use when creating the cluster"
+  type        = string
 }
 
 variable "environment" {
@@ -38,15 +38,15 @@ variable "environment" {
 }
 
 variable "es_application_logs_enabled" {
-  default       = false
-  description   = "A boolean value indicating whether application logs are enabled"
-  type          = bool
+  default     = false
+  description = "A boolean value indicating whether application logs are enabled"
+  type        = bool
 }
 
 variable "es_instance_count" {
-  default       = 1
-  description   = "The number of ElasticSearch EC2 instances to be provisioned"
-  type          = number
+  default     = 1
+  description = "The number of ElasticSearch EC2 instances to be provisioned"
+  type        = number
 }
 
 variable "es_instance_type" {
@@ -55,9 +55,9 @@ variable "es_instance_type" {
 }
 
 variable "index_slow_logs_enabled" {
-  default       = false
-  description   = "A boolean value indicating whether index slow logs are enabled"
-  type          = bool
+  default     = false
+  description = "A boolean value indicating whether index slow logs are enabled"
+  type        = bool
 }
 
 variable "region" {
@@ -66,15 +66,15 @@ variable "region" {
 }
 
 variable "repository_name" {
-  default       = "advanced-search-terraform"
-  description   = "The name of the repository in which we're operating"
-  type          = string
+  default     = "advanced-search-terraform"
+  description = "The name of the repository in which we're operating"
+  type        = string
 }
 
 variable "search_slow_logs_enabled" {
-  default       = false
-  description   = "A boolean value indicating whether search slow logs are enabled"
-  type          = bool
+  default     = false
+  description = "A boolean value indicating whether search slow logs are enabled"
+  type        = bool
 }
 
 variable "service" {
@@ -84,15 +84,15 @@ variable "service" {
 }
 
 variable "snapshots_enabled" {
-  default       = false
-  description   = "A boolean value indicating whether automated daily snapshots are enabled"
-  type          = bool
+  default     = false
+  description = "A boolean value indicating whether automated daily snapshots are enabled"
+  type        = bool
 }
 
 variable "snapshot_start_hour" {
-  default       = 23
-  description   = "Hour during which the service takes an automated daily snapshot of the indices in the domain"
-  type          = string
+  default     = 23
+  description = "Hour during which the service takes an automated daily snapshot of the indices in the domain"
+  type        = string
 }
 
 variable "team" {
@@ -102,12 +102,12 @@ variable "team" {
 }
 
 variable "volume_size" {
-  default       = 20
-  description   = "The volume size in GB"
-  type          = string
+  default     = 20
+  description = "The volume size in GB"
+  type        = string
 }
 
 variable "vpc_name" {
-  description   = "The name of the VPC into which we're provisioning"
-  type          = string
+  description = "The name of the VPC into which we're provisioning"
+  type        = string
 }

--- a/groups/advanced-search/vault-providers/userpass
+++ b/groups/advanced-search/vault-providers/userpass
@@ -1,11 +1,11 @@
 variable "hashicorp_vault_username" {
   description = "The username used when retrieving configuration from Hashicorp Vault"
-  type = string
+  type        = string
 }
 
 variable "hashicorp_vault_password" {
   description = "The password used when retrieving configuration from Hashicorp Vault"
-  type = string
+  type        = string
 }
 
 provider "vault" {


### PR DESCRIPTION
Upgrades codebase for TF 1.3
Replace deprecated `aws_subnet_ids` resources with `aws_subnets`
Replace deprecated `internal_cidrs` lookup with admin prefix list
Reworked `advanced-search` module to use a list of provided prefix list Ids
Refactored existing security group rules to remove inline config and replace with discreet resources
Pass with `terraform-fmt`
Update README